### PR TITLE
Pathを修正しllm-jp-evalとあわせ動作可能となるように修正

### DIFF
--- a/llm-jp-eval-inference/transformers/README.md
+++ b/llm-jp-eval-inference/transformers/README.md
@@ -17,7 +17,6 @@ venvによる典型的なインストール方法は次の通りです。
 （llm-jp-evalの`requirements.txt`のインストールは不要です）
 
 ```bash
-$ cd offline_inference/transformers
 $ python -m venv venv
 $ source venv/bin/activate
 $ pip install -r requirements_transformers_cuda121.txt  # CUDA 11.8の場合は`requirements_transformers_cuda118.txt`を使用

--- a/llm-jp-eval-inference/transformers/config_offline_inference_transformers.yaml
+++ b/llm-jp-eval-inference/transformers/config_offline_inference_transformers.yaml
@@ -1,7 +1,7 @@
 run_name: null  # This value will be applied to both offline_inference.run_name and wandb.run_name with the highest priority.
 
 offline_inference:
-  prompt_json_path: ["../../dataset/1.4.1/evaluation/test/prompts/*.eval-prompt.json"]
+  prompt_json_path: ["../../../dataset/1.4.1/evaluation/test/prompts/*.eval-prompt.json"]
   output_base_dir: "./outputs"
   run_name: null  # If null, the top level run_name or the default run_name determined by model configuration will be used. Do not specify both this value and top level run_name at the same time. The final output path is {output_base_dir}/{run_name}/
 

--- a/llm-jp-eval-inference/transformers/eval.sh
+++ b/llm-jp-eval-inference/transformers/eval.sh
@@ -23,8 +23,6 @@ OUTPUT_DIR=`egrep -r -h "^output_dir=" $LOG | head -n 1 | sed "s/output_dir=//"`
 rm $LOG
 deactivate
 
-cd ../..
-source venv/bin/activate
-python scripts/evaluate_llm.py offline_dir=$OUTPUT_DIR
-deactivate
+cd ../../../
+poetry run python scripts/evaluate_llm.py offline_dir="${OUTPUT_DIR}"
 cd -

--- a/llm-jp-eval-inference/trtllm/config_offline_inference_trtllm.yaml
+++ b/llm-jp-eval-inference/trtllm/config_offline_inference_trtllm.yaml
@@ -1,7 +1,7 @@
 run_name: null  # This value will be applied to both offline_inference.run_name and wandb.run_name with the highest priority.
 
 offline_inference:
-  prompt_json_path: ["../../dataset/1.4.1/evaluation/test/prompts/*.eval-prompt.json"]
+  prompt_json_path: ["../../../dataset/1.4.1/evaluation/test/prompts/*.eval-prompt.json"]
   output_base_dir: "./outputs"
   run_name: null  # If null, the top level run_name or the default run_name determined by model configuration will be used. Do not specify both this value and top level run_name at the same time. The final output path is {output_base_dir}/{run_name}/
 

--- a/llm-jp-eval-inference/trtllm/eval.sh
+++ b/llm-jp-eval-inference/trtllm/eval.sh
@@ -35,8 +35,6 @@ RUN_NAME=`egrep -r -h "^run_name=" $LOG | head -n 1 | sed "s/run_name=//"`
 OUTPUT_DIR=`egrep -r -h "^output_dir=" $LOG | head -n 1 | sed "s/output_dir=//"`
 rm $LOG
 
-cd ../..
-source venv/bin/activate
-python scripts/evaluate_llm.py offline_dir=$OUTPUT_DIR
-deactivate
+cd ../../..
+poetry run python scripts/evaluate_llm.py offline_dir="${OUTPUT_DIR}"
 cd -

--- a/llm-jp-eval-inference/vllm/config_offline_inference_vllm.yaml
+++ b/llm-jp-eval-inference/vllm/config_offline_inference_vllm.yaml
@@ -1,7 +1,7 @@
 run_name: null  # This value will be applied to both offline_inference.run_name and wandb.run_name with the highest priority.
 
 offline_inference:
-  prompt_json_path: ["../../dataset/1.4.1/evaluation/test/prompts/*.eval-prompt.json"]
+  prompt_json_path: ["../../../dataset/1.4.1/evaluation/test/prompts/*.eval-prompt.json"]
   output_base_dir: "./outputs"
   run_name: null  # If null, the top level run_name or the default run_name determined by model configuration will be used. Do not specify both this value and top level run_name at the same time. The final output path is {output_base_dir}/{run_name}/
 

--- a/llm-jp-eval-inference/vllm/eval.sh
+++ b/llm-jp-eval-inference/vllm/eval.sh
@@ -33,8 +33,6 @@ OUTPUT_DIR=`egrep -r -h "^output_dir=" $LOG | head -n 1 | sed "s/output_dir=//"`
 rm $LOG
 deactivate
 
-cd ../..
-source venv/bin/activate
-python scripts/evaluate_llm.py offline_dir=$OUTPUT_DIR
-deactivate
+cd ../../..
+poetry run python scripts/evaluate_llm.py offline_dir="${OUTPUT_DIR}"
 cd -


### PR DESCRIPTION
llm-jp-eval project rootへgit cloneした後に動作するようにpathのみ修正しました。