### PR TITLE
revise default max_model_len

### DIFF
--- a/inference-modules/vllm/schemas.py
+++ b/inference-modules/vllm/schemas.py
@@ -14,7 +14,7 @@ class ModelConfig(BaseModel):
     gpu_memory_utilization: float = 0.9
     tensor_parallel_size: int = 1
     pipeline_parallel_size: int = 1
-    max_model_len: int = 2048
+    max_model_len: int = 4096
     num_scheduler_steps: int = 8
     enable_prefix_caching: bool = True
 


### PR DESCRIPTION
max_model_len が 2048 になっていますが、
llm-jp-eval は全て 4096 を前提にしており、default の数値をそのまま引き継ぐと
色んなデータセットが評価できずエラーになります。
そのため、こちらの default を 4096 にする修正です。
Slackの方で関連したスレッドがありますので、宜しければそちらもご確認ください。