### PR TITLE
Fix output directory path construction

### DIFF
--- a/src/llm_jp_eval_inference/generator.py
+++ b/src/llm_jp_eval_inference/generator.py
@@ -184,7 +184,7 @@ class GeneratorBase(Generic[InferenceConfigT]):
 
     def execute(self) -> None:
         if self.is_master_process:
-            output_dir = Path(f"./{self.cfg.output_base_dir}/{self.cfg.run_name}")
+            output_dir = self.cfg.output_base_dir / str(self.cfg.run_name)
             os.makedirs(output_dir, exist_ok=True)
             print(f"output_dir={output_dir.resolve()}")
 

--- a/src/llm_jp_eval_inference/generator.py
+++ b/src/llm_jp_eval_inference/generator.py
@@ -7,7 +7,6 @@ import subprocess
 import sys
 
 from datetime import datetime
-from pathlib import Path
 from typing import Any, Dict, Generic, List, Tuple, TypeVar
 
 import torch


### PR DESCRIPTION
このプルリクエストでは推論の出力先ディレクトリのパス構築ロジックを修正する。既存の実装では `output_base_dir` はカレントディレクトリからの相対パスであると仮定されており、 `output_base_dir` に絶対パスを指定すると意図通りのディレクトリに出力されない。

`output_base_dir` は `pathlib.Path` タイプであるため、 `/` operatorでパスを結合する。これは相対パスを指定した場合でも既存の実装通りにカレントディレクトリからの相対パスとして動作する。